### PR TITLE
Added pragma mark to suppress unknown selector compiler warning

### DIFF
--- a/SlimeRefresh/SlimeRefresh/SRSlimeView.m
+++ b/SlimeRefresh/SlimeRefresh/SRSlimeView.m
@@ -153,8 +153,16 @@ NS_INLINE CGPoint pointLineToArc(CGPoint center, CGPoint p2, float angle, CGFloa
                 CGContextDrawPath(context, kCGPathFillStroke);
                 if (percent <= 0) {
                     _state = SRSlimeStateShortening;
+                    
+                    // pragma mark to suppress the warning
+                    // "performSelector may cause a leak because its selector is unknown"
+                    // applies only to the enclosed line
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
                     [_target performSelector:_action
                                   withObject:self];
+#pragma clang diagnostic pop
+                    
                     [self performSelector:@selector(scaling)
                                withObject:nil
                                afterDelay:kAnimationInterval


### PR DESCRIPTION
Added pragma mark to suppress unknown selector compiler warning "performSelector may cause a leak because its selector is unknown". The suppression only applies to the line in question and does not affect the rest of the code.

http://stackoverflow.com/questions/7017281/performselector-may-cause-a-leak-because-its-selector-is-unknown
