### PR TITLE
FIX: update contentOffset and contentInset synchronously when set loading with expansion

### DIFF
--- a/SlimeRefresh/SlimeRefresh/SRRefreshView.m
+++ b/SlimeRefresh/SlimeRefresh/SRRefreshView.m
@@ -137,11 +137,6 @@
                                             forKey:@""];
         //_slime.hidden = YES;
         _refleshView.hidden = YES;
-        if (!_scrollView.isDragging) {
-            UIEdgeInsets inset = _scrollView.contentInset;
-            inset.top = _upInset + _dragingHeight;
-            _scrollView.contentInset = inset;
-        }
         if (!_unmissSlime){
             _slime.state = SRSlimeStateMiss;
         }else {
@@ -173,10 +168,15 @@
 
 - (void)setLoadingWithexpansion
 {
+    [UIView animateWithDuration:0.2 animations:^() {
+        UIEdgeInsets inset = _scrollView.contentInset;
+        inset.top = _upInset + _dragingHeight;
+        _scrollView.contentInset = inset;
+        [_scrollView setContentOffset:CGPointMake(_scrollView.contentOffset.x,
+                                                  -_scrollView.contentInset.top)
+                             animated:NO];
+    }];
     self.loading = YES;
-    [_scrollView setContentOffset:CGPointMake(_scrollView.contentOffset.x,
-                                              -_scrollView.contentInset.top)
-                         animated:YES];
 }
 
 - (void)didMoveToSuperview


### PR DESCRIPTION
the tableview will get stuck for a while when we send message  "setLoadingWithExpansion"。I encountered this situation when i implementing "double click to refresh"
